### PR TITLE
fix: drawer example bar chart lines being black

### DIFF
--- a/src/components/component-preview/drawer-preview.tsx
+++ b/src/components/component-preview/drawer-preview.tsx
@@ -142,7 +142,7 @@ function DrawerDemo() {
 										dataKey="goal"
 										style={
 											{
-												fill: "hsl(var(--foreground))",
+												fill: "var(--foreground)",
 												opacity: 0.9,
 											} as React.CSSProperties
 										}


### PR DESCRIPTION
resolves #5 