### PR TITLE
fix: non-hex colors being capitalized in generated css

### DIFF
--- a/src/lib/colors/generate-user-colors-css.ts
+++ b/src/lib/colors/generate-user-colors-css.ts
@@ -112,7 +112,7 @@ export function generateUserColorsCss<
 
 					if (colorFormat === "hex") {
 						if (uppercaseHex) {
-							color = color.toUpperCase();
+							color = color.charAt(0) === "#" ? color.toUpperCase() : color;
 						} else {
 							color = color.toLowerCase();
 						}


### PR DESCRIPTION
Resolves #26 

Made sure the color starts with a pound sign before capitalizing it.